### PR TITLE
Add tests for external DbContext functions

### DIFF
--- a/src/Hangfire.EntityFrameworkCore/EFCoreStorageExtensions.cs
+++ b/src/Hangfire.EntityFrameworkCore/EFCoreStorageExtensions.cs
@@ -107,6 +107,10 @@ namespace Hangfire.EntityFrameworkCore
         {
             if (configuration is null)
                 throw new ArgumentNullException(nameof(configuration));
+            if (contextBuilder is null)
+                throw new ArgumentNullException(nameof(contextBuilder));
+            if (options is null)
+                throw new ArgumentNullException(nameof(options));
 
             return configuration.UseStorage(new EFCoreStorage(contextBuilder, options));
         }

--- a/tests/Hangfire.EntityFrameworkCore.Tests/DbContextOptionsTest.cs
+++ b/tests/Hangfire.EntityFrameworkCore.Tests/DbContextOptionsTest.cs
@@ -54,6 +54,12 @@ namespace Hangfire.EntityFrameworkCore.Tests
             return context;
         }
 
+        private protected DbContext CreateInMemoryContext()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder().UseSqlite(Connection);
+            return new HangfireContext(optionsBuilder.Options, string.Empty);
+        }
+
         private protected void UseContextSavingChanges(Action<HangfireContext> action)
         {
             UseContext(context =>

--- a/tests/Hangfire.EntityFrameworkCore.Tests/EFCoreStorageExtensionsFacts.cs
+++ b/tests/Hangfire.EntityFrameworkCore.Tests/EFCoreStorageExtensionsFacts.cs
@@ -83,6 +83,56 @@ namespace Hangfire.EntityFrameworkCore.Tests
         }
 
         [Fact]
+        public static void UseEFCoreStorageFactory_Throws_WhenConfigurationParameterIsNull()
+        {
+            IGlobalConfiguration configuration = null;
+            Func<DbContext> contextBuilder = () => new Mock<DbContext>().Object;
+            EFCoreStorageOptions options = new Mock<EFCoreStorageOptions>().Object;
+
+            Assert.Throws<ArgumentNullException>(nameof(configuration),
+                () => configuration.UseEFCoreStorage(contextBuilder, options));
+        }
+
+        [Fact]
+        public static void UseEFCoreStorageFactory_Throws_WhenContextBuilderParameterIsNull()
+        {
+            IGlobalConfiguration configuration = new Mock<IGlobalConfiguration>().Object;
+            Func<DbContext> contextBuilder = null;
+            EFCoreStorageOptions options = new Mock<EFCoreStorageOptions>().Object;
+
+            Assert.Throws<ArgumentNullException>(nameof(contextBuilder),
+                () => configuration.UseEFCoreStorage(contextBuilder, options));
+        }
+
+        [Fact]
+        public static void UseEFCoreStorageFactory_Throws_WhenOptionsParameterIsNull()
+        {
+            IGlobalConfiguration configuration = new Mock<IGlobalConfiguration>().Object;
+            Func<DbContext> contextBuilder = () => new Mock<DbContext>().Object;
+            EFCoreStorageOptions options = null;
+
+            Assert.Throws<ArgumentNullException>(nameof(options),
+                () => configuration.UseEFCoreStorage(contextBuilder, options));
+        }
+
+        [Fact]
+        public static void UseEFCoreStorageFactory_CompletesSuccessfully()
+        {
+            var configurationMock = new Mock<IGlobalConfiguration>();
+            var configuration = configurationMock.Object;
+            var options = new EFCoreStorageOptions();
+
+            Func<DbContext> contextBuilder = () => new Mock<DbContext>().Object;
+
+            var result = configuration.UseEFCoreStorage(contextBuilder, options);
+
+            Assert.NotNull(result);
+            var genericConfiguration =
+                Assert.IsAssignableFrom<IGlobalConfiguration<EFCoreStorage>>(result);
+            Assert.NotNull(genericConfiguration.Entry);
+        }
+
+        [Fact]
         public static void UseDatabaseCreator_Throws_WhenStorageParameterIsNull()
         {
             var configuration = default(IGlobalConfiguration<EFCoreStorage>);

--- a/tests/Hangfire.EntityFrameworkCore.Tests/EFCoreStorageFacts.cs
+++ b/tests/Hangfire.EntityFrameworkCore.Tests/EFCoreStorageFacts.cs
@@ -95,6 +95,14 @@ namespace Hangfire.EntityFrameworkCore.Tests
         }
 
         [Fact]
+        public void CreateContext_FactoryCreatesInstance()
+        {
+            var instance = FactoryStorage.CreateContext();
+            Assert.NotNull(instance);
+            instance.Dispose();
+        }
+
+        [Fact]
         public void UseContext_Throws_WhenActionParameterIsNull()
         {
             Action<DbContext> action = null;

--- a/tests/Hangfire.EntityFrameworkCore.Tests/EFCoreStorageTest.cs
+++ b/tests/Hangfire.EntityFrameworkCore.Tests/EFCoreStorageTest.cs
@@ -13,6 +13,7 @@ namespace Hangfire.EntityFrameworkCore.Tests
     public abstract class EFCoreStorageTest : DbContextOptionsTest
     {
         private EFCoreStorage _storage;
+        private EFCoreStorage _factoryStorage;
 
         private protected EFCoreStorage Storage =>
             LazyInitializer.EnsureInitialized(ref _storage,
@@ -23,6 +24,12 @@ namespace Hangfire.EntityFrameworkCore.Tests
                         context => context.Database.EnsureCreated());
                     return storage;
                 });
+
+        private protected EFCoreStorage FactoryStorage =>
+            LazyInitializer.EnsureInitialized(ref _factoryStorage,
+                () => new EFCoreStorage(
+                    CreateInMemoryContext,
+                    new EFCoreStorageOptions()));
 
         private protected static string InvocationDataStub { get; } =
             JobHelper.ToJson(new InvocationData(null, null, null, string.Empty));


### PR DESCRIPTION
Add tests for the external DbContext functions.

Most of the of the changes that were made by the external DbContext changes are covered by the existing test suite, this change will add some new tests covering the global configuration extension methods as well as the create instance inside the EfCoreStorage class.

Also adds some null checks to the Global configuration extension methods that were missed in the original ticket.

Resolves #12 