### PR TITLE
Remove the the Expiration Manager from explicitly starting a transaction

### DIFF
--- a/src/Hangfire.EntityFrameworkCore/ExpirationManager.cs
+++ b/src/Hangfire.EntityFrameworkCore/ExpirationManager.cs
@@ -60,7 +60,6 @@ internal class ExpirationManager : IServerComponent
                 // Trying to set StateId = null for all fetched jobs first
                 foreach (var entry in entries)
                     entry.Property(x => x.StateId).IsModified = true;
-                using var transaction = context.Database.BeginTransaction();
 
                 try
                 {
@@ -69,7 +68,6 @@ internal class ExpirationManager : IServerComponent
                 catch (DbUpdateConcurrencyException)
                 {
                     // Someone else already has removed item, database wins. Just try again.
-                    transaction.Rollback();
                     return -1;
                 }
 
@@ -84,10 +82,8 @@ internal class ExpirationManager : IServerComponent
                 catch (DbUpdateConcurrencyException)
                 {
                     // Someone else already has removed item, database wins. Just try again.
-                    transaction.Rollback();
                     return -1;
                 }
-                transaction.Commit();
                 return affected;
             }));
         });


### PR DESCRIPTION
Removing the explicit transaction creation due to the fact that the underlying DbContext may have an Execution Policy that does not allow for Transactions to be explicitly created