### PR TITLE
Avoid from/to in bind variables

### DIFF
--- a/src/Hangfire.EntityFrameworkCore/EFCoreJobQueueMonitoringApi.cs
+++ b/src/Hangfire.EntityFrameworkCore/EFCoreJobQueueMonitoringApi.cs
@@ -105,11 +105,11 @@ internal sealed class EFCoreJobQueueMonitoringApi : IPersistentJobQueueMonitorin
             LongCount();
 
     private static Expression<GetJobIdsFunc> GetJobIdsExpression(QueuedJobPredicate predicate)
-        => (DbContext context, string queue, int from, int perPage) => (
+        => (DbContext context, string queue, int skip, int perPage) => (
             from x in context.Set<HangfireQueuedJob>().Where(predicate)
             where x.Queue == queue
             orderby x.Id ascending
             select x.Id).
-            Skip(from).
+            Skip(skip).
             Take(perPage);
 }

--- a/src/Hangfire.EntityFrameworkCore/EFCoreStorageConnection.cs
+++ b/src/Hangfire.EntityFrameworkCore/EFCoreStorageConnection.cs
@@ -55,9 +55,9 @@ internal class EFCoreStorageConnection : JobStorageConnection
             Sum(x => x.Value));
 
     private static GetFirstByLowestScoreFromSetFunc GetFirstByLowestScoreFromSetFunc { get; } = EF.CompileQuery(
-        (DbContext context, string key, double from, double to) => (
+        (DbContext context, string key, double from_score, double to_score) => (
             from x in context.Set<HangfireSet>()
-            where x.Key == key && @from <= x.Score && x.Score <= to
+            where x.Key == key && from_score <= x.Score && x.Score <= to_score
             orderby x.Score
             select x.Value).
             FirstOrDefault());
@@ -105,11 +105,11 @@ internal class EFCoreStorageConnection : JobStorageConnection
             Min());
 
     private static GetRangeFromListFunc GetRangeFromListFunc { get; } = EF.CompileQuery(
-        (DbContext context, string key, int from, int to) =>
+        (DbContext context, string key, int from_pos, int to_pos) =>
             from x in context.Set<HangfireList>()
             where x.Key == key
             let position = x.Position
-            where @from <= position && position <= to
+            where from_pos <= position && position <= to_pos
             orderby position descending
             select x.Value);
 

--- a/src/Hangfire.EntityFrameworkCore/EFCoreStorageMonitoringApi.cs
+++ b/src/Hangfire.EntityFrameworkCore/EFCoreStorageMonitoringApi.cs
@@ -52,7 +52,7 @@ internal class EFCoreStorageMonitoringApi : IMonitoringApi
             select new KeyValuePair<string, string>(x.Name, x.Value));
 
     private static GetStateDataFunc GetStateDataFunc { get; } = EF.CompileQuery(
-        (DbContext context, string name, int from, int count) => (
+        (DbContext context, string name, int skip, int count) => (
             from x in context.Set<HangfireJob>()
             where x.StateName == name
             let s = x.State
@@ -64,7 +64,7 @@ internal class EFCoreStorageMonitoringApi : IMonitoringApi
                 Reason = s.Reason,
                 Data = s.Data,
             }).
-            Skip(from).
+            Skip(skip).
             Take(count));
 
     private static GetStateHistoryFunc GetStateHistoryFunc { get; } = EF.CompileQuery(


### PR DESCRIPTION
Hello Sergey, thank you for this great package! I tested it with Oracle.EntityFrameworkCore, and it failed because Oracle does not allow reserved words like "from" and "to" as bind variables. I renamed them to avoid this conflict.

Example:

      SELECT "h"."Value"
      FROM "HangfireSet" "h"
      WHERE (((("h"."Key" = :key) AND (:from <= "h"."Score"))) AND ("h"."Score" <= :to))
      ORDER BY "h"."Score"
      FETCH FIRST 1 ROWS ONLY
      
Leads to this error:

ORA-01745: Invalid host-/bind Variable Name